### PR TITLE
Aggiunte operazioni di casting in alcune assegnazioni/confronti

### DIFF
--- a/Fantacalcio.py
+++ b/Fantacalcio.py
@@ -178,7 +178,7 @@ def appetibilita(df: pd.DataFrame) -> float:
             appetibilita = float(row[7]) * int(row[5]) / 38 
 
         # media pesata fantamedia * convenienza rispetto alla quotazione * media scorso anno
-        appetibilita=appetibilita*row['Punteggio']*30/100
+        appetibilita=appetibilita*float(row['Punteggio'])*30/100
         if float(row[1]) == 0: pt=1
         else: pt=float(row[1])
         appetibilita = (
@@ -197,7 +197,7 @@ def appetibilita(df: pd.DataFrame) -> float:
 
         if row["Nuovo acquisto"]:
             appetibilita -= 2
-        if row["Buon investimento"] == 60:
+        if int(row["Buon investimento"]) == 60:
             appetibilita += 3
         if row["Consigliato prossima giornata"]:
             appetibilita += 1
@@ -205,9 +205,9 @@ def appetibilita(df: pd.DataFrame) -> float:
             appetibilita += 2
         if row["Infortunato"]:
             appetibilita -= 1
-        if row["Resistenza infortuni"] > 60:
+        if int(row["Resistenza infortuni"]) > 60:
             appetibilita += 4
-        if row["Resistenza infortuni"] == 60:
+        if int(row["Resistenza infortuni"]) == 60:
             appetibilita += 2
 
         res.append(appetibilita)

--- a/Fantacalcio.py
+++ b/Fantacalcio.py
@@ -275,6 +275,6 @@ if __name__ == "__main__":
     ]
     df.sort_values(by="Convenienza", ascending=False)
 
-    # df.to_csv("giocatori_appet.csv", index=False)
+    #df.to_csv("giocatori_appet.csv", index=False)
     df.to_excel("giocatori_excel.xls")
     logger.debug("Finito!")


### PR DESCRIPTION
In alcune assegnazioni si tentava di moltiplicare una stringa (che rappresentava comunque un numero) per un float. 
In alcuni confronti si tentava di confrontare una stringa (che rappresentava comunque un numero) per un intero. 
Se si tentava di eseguire il codice il primo tentativo non generava nessun file excel (o csv) e solo nella seconda esecuzione del codice era possibile poi visualizzare il file excel.
Aggiungendo il casting nelle assegnazioni/confronti che lo richiedevano era possibile visualizzare il file excel alla prima esecuzione del codice.
![issuefantacalcio](https://user-images.githubusercontent.com/59175940/184116168-6685ff32-20ff-45d6-9024-ea82edd1484a.png)
