### PR TITLE
Fix missing FORCE_SCRAPE_URL in config.py. Add more vscode debug configurations.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -83,5 +83,59 @@
                 "fstats"
             ]
         },
+        {
+            "name": "cli analyze",
+            "type": "debugpy",
+            "request": "launch",
+			"python": "${workspaceFolder}/.venv/Scripts/python",
+            "cwd": "${workspaceFolder}",
+            "module": "cli",
+            "justMyCode": false,
+            "args": [
+                "analyze"
+            ]
+        },
+        {
+            "name": "cli analyze [JSON]",
+            "type": "debugpy",
+            "request": "launch",
+			"python": "${workspaceFolder}/.venv/Scripts/python",
+            "cwd": "${workspaceFolder}",
+            "module": "cli",
+            "justMyCode": false,
+            "args": [
+                "analyze",
+                "-f",
+                "json"
+            ]
+        },
+        {
+            "name": "cli analyze [FPEDIA]",
+            "type": "debugpy",
+            "request": "launch",
+			"python": "${workspaceFolder}/.venv/Scripts/python",
+            "cwd": "${workspaceFolder}",
+            "module": "cli",
+            "justMyCode": false,
+            "args": [
+                "analyze",
+                "-s",
+                "fpedia"
+            ]
+        },
+        {
+            "name": "cli analyze [FSTAT]",
+            "type": "debugpy",
+            "request": "launch",
+			"python": "${workspaceFolder}/.venv/Scripts/python",
+            "cwd": "${workspaceFolder}",
+            "module": "cli",
+            "justMyCode": false,
+            "args": [
+                "analyze",
+                "-s",
+                "fstats"
+            ]
+        }
     ]
 }

--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
 }
 FORCE_SCRAPING_MAIN = True # Forza lo scraping anche se i file esistono
+FORCE_SCRAPE_URLS = True # Forza il re-scraping degli URL dei giocatori
 
 # Costanti per il calcolo della convenienza
 PESO_FANTAMEDIA = 0.6


### PR DESCRIPTION
Risolto il problema della variabile mancante FORCE_SCRAPE_URLS in `config.py`, ora correttamente definita per forzare il re-scraping degli URL dei giocatori.
Aggiunte nuove configurazioni di debug in `launch.json` per facilitare l’avvio e il debug dei comandi analyze della CLI, con varianti per output JSON, FPEDIA e FSTAT.