### PR TITLE
Fix TypeError with OUTPUT_DIR Sentinel object

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -178,7 +178,7 @@ def scrape(ctx, source, force):
     default="all",
     help="Data source to analyze",
 )
-@click.option("--output", "-o", type=click.Path(), help="Custom output directory")
+@click.option("--output", "-o", type=click.Path(), default=None, help="Custom output directory")
 @click.option("--top", "-t", type=int, default=50, help="Show top N players in summary")
 @click.pass_context
 def analyze(ctx, source, output, top):


### PR DESCRIPTION
## Summary
Fixes issue #13: TypeError when running `poetry run python cli.py run --source fpedia`

## Root Cause
Click 8.1.7 passes a `Sentinel.UNSET` object to the `output` parameter when:
- The `run` command invokes `analyze` without explicitly passing the `output` parameter (cli.py:439)
- The `--output` option lacks an explicit `default` value (cli.py:181)
- Since Sentinel is truthy, the `if output:` check at line 193 attempts to use it as a path, causing the TypeError

## Solution
Added `default=None` to the `--output` option at cli.py:181:
```python
@click.option("--output", "-o", type=click.Path(), default=None, help="Custom output directory")
```

This ensures the parameter receives `None` when not specified, instead of `Sentinel.UNSET`.

## Testing
- Verified `poetry run python cli.py run --source fpedia` completes successfully (551 players processed)
- Verified output files created in `data/output/` directory
- Tested `analyze` command with and without `--output` parameter
- Tested custom output path functionality

## Changes
- cli.py line 181: Added `default=None` to `--output` option

Closes #13