### PR TITLE
Remove duplicate player URLs in get_giocatori_urls function

### DIFF
--- a/data_retriever.py
+++ b/data_retriever.py
@@ -34,6 +34,9 @@ def get_giocatori_urls(force=True) -> list:
                 logger.error(f"Failed to retrieve URLs for role '{ruolo}': {e}")
                 continue
 
+        # Roles overlap on FPEDIA (e.g. Trequartisti are also listed under Centrocampisti)
+        giocatori_urls = list(dict.fromkeys(giocatori_urls))
+
         if not giocatori_urls:
             logger.warning(
                 "No player URLs were scraped from FPEDIA. "


### PR DESCRIPTION
This pull request makes a small but important improvement to the `get_giocatori_urls` function in `data_retriever.py`. The change ensures that the list of player URLs does not contain duplicates, addressing the issue of overlapping roles on FPEDIA.

* Deduplication of player URLs: After collecting URLs for all roles, the code now removes duplicates by converting the list to a dictionary and back to a list. This ensures that each player URL appears only once, even if their roles overlap (e.g., Trequartisti also listed as Centrocampisti).